### PR TITLE
Change transit gateway configs

### DIFF
--- a/templates/transit-gateway.yaml
+++ b/templates/transit-gateway.yaml
@@ -32,7 +32,8 @@ Resources:
       # AmazonSideAsn: 65000
       Description: Transit gateway for Sage corp
       AutoAcceptSharedAttachments: "enable"
-      DefaultRouteTableAssociation: "enable"
+      DefaultRouteTableAssociation: "disable"
+      DefaultRouteTablePropagation: "disable"
       DnsSupport: "enable"
       VpnEcmpSupport: "enable"
       Tags:


### PR DESCRIPTION
We don't want the transit gateway to automatically create routes for
each VPC attachment that we add.  We want to define more grandular routes
between each attached VPC.