### PR TITLE
Setup transit gateway route table associations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
   - pip install pre-commit sceptre sceptre-ssm-resolver
+  - pip install git+git://github.com/zaro0508/sceptre-identity-resolver.git
 stages:
   - name: validate
   - name: deploy

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ The purpose of this account is to run the AWS transit gateway as the
 AWS enforces a specific workflow when setting up the Transit Gateway in a hub
 and spoke architecture.
 
-1. Setup the transit gateway in the central/hub account
-2. Share the transit gateway in the hub account (VPC settings).
-3. Share the transit gateway to spoke accounts with the Resource Access Manager.
-4. Accept invitations from spoke account in the Resource Access Manager.
-5. Create attachments to the transit gateway hub from spoke accounts.
-6. Create a transit gateway route table in the hub account.
+1. Setup the transit gateway in the central/hub account.
+2. Create a transit gateway route table in the hub account.
+3. Share the transit gateway in the hub account (VPC settings).
+4. Share the transit gateway to spoke accounts with the Resource Access Manager.
+5. Accept invitations from spoke account in the Resource Access Manager.
+6. Create attachments to the transit gateway hub from spoke accounts.
 7. Add ("Associate") spoke TGW attachments to the hub transit gateway route table.
 
 ### Setup a Hub
@@ -23,18 +23,28 @@ Setup a transit gateway("hub") and send invitations to share the
 transit gateway to spoke accounts defined in the `TgwSharedPrincipals`
 parameter.
 
+#### Create a transit gateway
+First step is to create the transit gateway, create a TGW route table, share the TGW
+with within the transit account, then use the AWS resource access manager to share
+the TGW to the spoke accounts.
+
 1. Create a sceptre config template similar to config/prod/sage-tgw.yaml
 2. Deploy the hub template:
 `
 sceptre --var "profile=transit" --var "region=us-east-1" launch --yes prod/new-tgw.yaml
 `
-3. Login to the AWS transit account then navigate to VPC -> Transit Gateways ->
+
+__Note__: That template takes care of creating the TGW, creating the route table,
+and sending an invition to share the TGW to spoke accounts.  However it does not
+setup sharing within the same account.
+
+#### Share the transit gateway
+__Note__: The TGW must be shared within the transit account. Neither cloudformation nor
+the aws cli support configuring the TGW `sharing` setting.
+
+Login to the AWS transit account then navigate to VPC -> Transit Gateways ->
 Select the newly provisioned transit gateway -> Sharing tab ->
 Share transit gateway -> Share.
-
-__Note__: This TGW must be shared. Neither cloudformation nor the aws cli support
-setting the `sharing` config.
-
 
 ### Setup a Spoke
 Setting up the spoke account is a two step process.  First is to accept the
@@ -61,6 +71,18 @@ a sceptre template similar to
 `
 sceptre --var "profile=transit" --var "region=us-east-1" launch --yes prod/sage-tgw-sandcastlevpc-attachment.yaml
 `
+
+### Add spoke TGW attachments
+__Note__: This step depends on having already completed `Setup a Hub` and `Setup a Spoke`.
+
+1. Create a sceptre config template similar to config/prod/sage-tgw-associations.yaml
+2. Deploy the template:
+`
+sceptre --var "profile=transit" --var "region=us-east-1" launch --yes prod/sage-tgw-association.yaml
+`
+
+That template will associate VPCs to your new route table.
+
 
 ## Instructions to create or update CF stacks
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ and spoke architecture.
 3. Share the transit gateway to spoke accounts with the Resource Access Manager.
 4. Accept invitations from spoke account in the Resource Access Manager.
 5. Create attachments to the transit gateway hub from spoke accounts.
-6. Setup transit gateway VPC routes in the hub account.
-
+6. Create a transit gateway route table in the hub account.
+7. Add ("Associate") spoke TGW attachments to the hub transit gateway route table.
 
 ### Setup a Hub
 Setup a transit gateway("hub") and send invitations to share the
@@ -34,6 +34,7 @@ Share transit gateway -> Share.
 
 __Note__: This TGW must be shared. Neither cloudformation nor the aws cli support
 setting the `sharing` config.
+
 
 ### Setup a Spoke
 Setting up the spoke account is a two step process.  First is to accept the

--- a/config/prod/sage-tgw-associations.yaml
+++ b/config/prod/sage-tgw-associations.yaml
@@ -3,9 +3,11 @@ stack_name: "TransitGatewayAssociation"
 dependencies:
   - "prod/sage-tgw.yaml"
 parameters:
-  TgwRouteTableId: "tgw-rtb-070d3a113bf29aac6" # sage-tgw
+  TgwRouteTableName: "sage-tgw"
 sceptre_user_data:
   stackname: !stack_name
   tgw_attachment_ids:
     - "tgw-attach-00209ee1f8bf96deb"  # sandbox/sandcastlevpc
     - "tgw-attach-0eda99de834959854"  # itsandbox/dustbunnyvpc
+    - "tgw-attach-07e89a05b741f9505"  # scicomp/computevpc
+    - "tgw-attach-0c0095ff57f6f1662"  # scicomp/snowflakevpc

--- a/config/prod/transit-gateway-associations.yaml
+++ b/config/prod/transit-gateway-associations.yaml
@@ -1,0 +1,11 @@
+template_path: "transit-gateway-associations.j2"
+stack_name: "TransitGatewayAssociation"
+dependencies:
+  - "prod/sage-tgw.yaml"
+parameters:
+  TgwRouteTableId: "tgw-rtb-070d3a113bf29aac6" # sage-tgw
+sceptre_user_data:
+  stackname: !stack_name
+  tgw_attachment_ids:
+    - "tgw-attach-00209ee1f8bf96deb"  # sandbox/sandcastlevpc
+    - "tgw-attach-0eda99de834959854"  # itsandbox/dustbunnyvpc

--- a/templates/transit-gateway-associations.j2
+++ b/templates/transit-gateway-associations.j2
@@ -1,17 +1,16 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: "Setup transit gateway route associations"
 Parameters:
-  TgwRouteTableId:
-    Description: 'The transit gateway route table ID'
+  TgwRouteTableName:
+    Description: 'The transit gateway route table name'
     Type: String
-    AllowedPattern: '^tgw-rtb-[a-z0-9]+$'
-    ConstraintDescription: 'Must be a TGW route table ID (i.e "tgw-rtb-111111")'
 Resources:
 {% for tgw_attachment_id in sceptre_user_data.tgw_attachment_ids %}
   {{ sceptre_user_data.stackname }}{{ loop.index }}:
       Type: AWS::EC2::TransitGatewayRouteTableAssociation
       Properties:
-        TransitGatewayRouteTableId: !Ref TgwRouteTableId
+        TransitGatewayRouteTableId: !ImportValue
+          'Fn::Sub': '${AWS::Region}-${TgwRouteTableName}-TransitGatewayRouteTable'
         TransitGatewayAttachmentId: {{ tgw_attachment_id }}
 {% endfor %}
 

--- a/templates/transit-gateway-associations.j2
+++ b/templates/transit-gateway-associations.j2
@@ -1,0 +1,25 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: "Setup transit gateway route associations"
+Parameters:
+  TgwRouteTableId:
+    Description: 'The transit gateway route table ID'
+    Type: String
+    AllowedPattern: '^tgw-rtb-[a-z0-9]+$'
+    ConstraintDescription: 'Must be a TGW route table ID (i.e "tgw-rtb-111111")'
+Resources:
+{% for tgw_attachment_id in sceptre_user_data.tgw_attachment_ids %}
+  {{ sceptre_user_data.stackname }}{{ loop.index }}:
+      Type: AWS::EC2::TransitGatewayRouteTableAssociation
+      Properties:
+        TransitGatewayRouteTableId: !Ref TgwRouteTableId
+        TransitGatewayAttachmentId: {{ tgw_attachment_id }}
+{% endfor %}
+
+Outputs:
+{% for tgw_attachment_id in sceptre_user_data.tgw_attachment_ids %}
+  {{ sceptre_user_data.stackname }}{{ loop.index  }}:
+    Description: This Is the transit gateway association
+    Value: !Ref {{ sceptre_user_data.stackname }}{{ loop.index  }}
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-{{ loop.index  }}'
+{% endfor %}


### PR DESCRIPTION
Associate each spoke TGW attachment to the hub TGW.
This template depends the existing TGW attachments to be in place
there this can only be executed after spoke attachments
have been setup.