### PR TITLE
[IT-1007] Fix VPN setup

### DIFF
--- a/config/prod/sage-client-vpn.yaml
+++ b/config/prod/sage-client-vpn.yaml
@@ -23,10 +23,14 @@ sceptre_user_data:
     - !stack_output_external unionstationvpc::PrivateSubnet2
   TgwSpokes:
     # "10.50.0.0/16" (unionstationvpc) route automatically setup by the VPN endpoint association
+    # AccessGroups must match Jumpcloud groups
+
+    # org-sagebase-itsandbox
     dustbunnyvpc:
       CIDR: "10.29.0.0/16"
       AccessGroups:
         - "admin"
+    # org-sagebase-sandbox
     sandcastlevpc:
       CIDR: "10.23.0.0/16"
       AccessGroups:
@@ -34,34 +38,34 @@ sceptre_user_data:
         - "scientists"
     # org-sagebase-scicomp
     computevpc:
-      CIDR: "10.29.0.0/16"
+      CIDR: "10.5.0.0/16"
       AccessGroups:
         - "admin"
         - "aws-scicomp-developers"
     snowflakevpc:
-      CIDR: "10.29.0.0/16"
+      CIDR: "10.25.0.0/16"
       AccessGroups:
         - "admin"
         - "aws-scicomp-developers"
     iatlasvpc:
-      CIDR: "10.29.0.0/16"
+      CIDR: "10.255.20.0/24"
       AccessGroups:
         - "admin"
     # org-sagebase-scipooldev
     cesspoolvpc:
-      CIDR: "10.29.0.0/16"
+      CIDR: "10.31.0.0/16"
       AccessGroups:
         - "admin"
         - "aws-scicomp-developers"
     # org-sagebase-scipoolprod
     internalpoolvpc:
-      CIDR: "10.29.0.0/16"
+      CIDR: "10.41.0.0/16"
       AccessGroups:
         - "admin"
         - "aws-scicomp-developers"
     # org-sagebase-strides
     stridespoolvpc:
-      CIDR: "10.29.0.0/16"
+      CIDR: "10.49.0.0/16"
       AccessGroups:
         - "admin"
         - "aws-scicomp-developers"

--- a/templates/client-vpn.j2
+++ b/templates/client-vpn.j2
@@ -81,7 +81,7 @@ Resources:
 {%   set spoke_loop = loop %}
 {%   for access_group in spoke_data.AccessGroups %}
 {%     set access_group_loop = loop %}
-  {{ spoke }}{{ access_group }}VpnEndpointAuthorization:
+  VpnEndpointAuthorization{{ spoke_loop.index }}{{ access_group_loop.index }}:
     Type: AWS::EC2::ClientVpnAuthorizationRule
     DependsOn:
 {%     for subnet_id in sceptre_user_data.SubnetIds %}
@@ -99,14 +99,14 @@ Resources:
 {%   set spoke_loop = loop %}
 {%   for subnet_id in sceptre_user_data.SubnetIds %}
 {%     set subnet_id_loop = loop %}
-  {{ spoke }}VpnEndpointRoute{{ subnet_id_loop.index }}:
+  VpnEndpointRoute{{ spoke_loop.index }}{{ subnet_id_loop.index }}:
     Type: AWS::EC2::ClientVpnRoute
     DependsOn:
 {%     for depend in sceptre_user_data.SubnetIds %}
       - VpnEndpointAssociation{{ loop.index }}
 {%     endfor %}
     Properties:
-      Description: {{ spoke }}
+      Description: {{ spoke }}-{{ subnet_id }}
       ClientVpnEndpointId: !Ref VpnEndpoint
       DestinationCidrBlock: {{ spoke_data.CIDR }}
       TargetVpcSubnetId: {{ subnet_id }}


### PR DESCRIPTION
* Using spoke and AccessGroup names for resource names is a bad idea
  because it may contain invalid characters such as '-' or '_'.
* Fix duplate CIDRs