### PR TITLE
Don't use spoke for resource name

### DIFF
--- a/templates/transit-gateway-routes.j2
+++ b/templates/transit-gateway-routes.j2
@@ -10,7 +10,7 @@ Parameters:
     Type: String
 Resources:
 {% for spoke, spoke_data in sceptre_user_data.TgwSpokes.items() %}
-  VpcRouteTable{{spoke}}:
+  VpcRouteTable{{ loop.index }}:
     Type: AWS::EC2::Route
     Properties:
       DestinationCidrBlock: "{{ spoke_data.CIDR }}"


### PR DESCRIPTION
spoke names can have invalid characters for resources, like `-` or `_`
Append numbers instead of spoke name for resource name.